### PR TITLE
Added solutions remove duplicate from linkedList

### DIFF
--- a/DataStructuresAndAlgorithms/DataStructuresAndAlgorithms.csproj
+++ b/DataStructuresAndAlgorithms/DataStructuresAndAlgorithms.csproj
@@ -43,7 +43,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ILinkedListSolutions.cs" />
+    <Compile Include="LinkedListSolutions.cs" />
     <Compile Include="IStringSolutions.cs" />
+    <Compile Include="MyList.cs" />
+    <Compile Include="Node.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringSolutions.cs" />

--- a/DataStructuresAndAlgorithms/ILinkedListSolutions.cs
+++ b/DataStructuresAndAlgorithms/ILinkedListSolutions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataStructuresAndAlgorithms
+{
+    public interface ILinkedListSolutions
+    {
+        Node RemoveDuplicateFromSortedList(Node head);
+        Node RemoveDuplicateFromUnsortedList(Node head);
+        Node RemoveDuplicateFromUnsortedWithHashSet(Node head);
+    }
+}

--- a/DataStructuresAndAlgorithms/LinkedListSolutions.cs
+++ b/DataStructuresAndAlgorithms/LinkedListSolutions.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataStructuresAndAlgorithms
+{
+    public class LinkedListSolutions:ILinkedListSolutions
+    {
+        /// <summary>
+        /// Given a head node of a sorted linked list, this algorithm removes duplicate from the linked list by 
+        /// comparing the neighboring nodes
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        public Node RemoveDuplicateFromSortedList(Node head)
+        {
+            Node currentNode = head;
+
+            //traverse through the linked list and compare every node with the next node until next node is null
+            while(currentNode != null && currentNode.next != null)
+            {
+                if(currentNode.value == currentNode.next.value)
+                {
+                    currentNode.next = currentNode.next.next;
+                }
+                else
+                {
+                    currentNode = currentNode.next;
+                }
+            }
+            return head;
+        }
+
+        /// <summary>
+        /// Given a head node of an unsorted linked list, this algorithm removes duplicate from the linked list
+        /// using hashset.
+        /// This has a complexsity of O(n) as the algorithm traverse throught all the nodes in the list 
+        /// The time complexity to access item from he hashset is O(1)
+        /// Therefore, this is the best we can do
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+
+        public Node RemoveDuplicateFromUnsortedWithHashSet(Node node)
+        {
+            HashSet<int> hashSet = new HashSet<int>();
+            Node current = node;
+            Node previus = null;
+            while (current!= null)
+            {
+                if (hashSet.Contains(current.value))
+                {
+                    previus.next = current.next;
+                }
+                else
+                {
+                    hashSet.Add(current.value);
+                    previus = current;
+                }
+                current = current.next;
+            }
+
+            return node;
+        }
+
+        /// <summary>
+        /// Given a head node of an unsorted linked list, this algorithm removes duplicate from the linked list
+        /// by using 2 pointers, for each current node, we traverse through the list using the runner node.
+        /// This gives us O(n) square
+        /// This is not an optimal solution
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        public Node RemoveDuplicateFromUnsortedList(Node head)
+        {
+            Node current = head;
+            while (current != null)
+            {
+               Node  runner = current;
+                while (runner.next != null)
+                {
+                    if (current.value == runner.next.value)
+                    {
+                        runner.next = runner.next.next;
+                    }
+                    else
+                    {
+                        runner = runner.next;
+                    }
+                }
+                current = current.next;
+            }
+            return head;
+        }
+    }
+}

--- a/DataStructuresAndAlgorithms/Node.cs
+++ b/DataStructuresAndAlgorithms/Node.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataStructuresAndAlgorithms
+{
+    public class Node
+    {
+        public int value;
+        public Node next;
+
+        public Node(int value)
+        {
+            this.value = value;
+            this.next = null;
+        }
+    }
+}

--- a/DataStructuresAndAlgorithmsTest/LinkedListSolutionShould.cs
+++ b/DataStructuresAndAlgorithmsTest/LinkedListSolutionShould.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Xunit;
+using Moq;
+using DataStructuresAndAlgorithms;
+
+namespace DataStructuresAndAlgorithmsTest
+{
+    public class LinkedListSolutionShould
+    {
+        ILinkedListSolutions _linkedListSolutions;
+        public LinkedListSolutionShould()
+        {
+            _linkedListSolutions = new LinkedListSolutions();
+        }
+
+        [Fact]
+        public void RemoveDuplicateFromSortedList_WithHeadNode_ReturnsResult()
+        {
+            Node headNode = new Node(1);
+            headNode.next = new Node(2);
+            headNode.next.next = new Node(3);
+            headNode.next.next.next = new Node(3);
+            headNode.next.next.next.next = new Node(4);
+            headNode.next.next.next.next.next = new Node(5);
+            headNode.next.next.next.next.next.next = new Node(6);
+            headNode.next.next.next.next.next.next.next = new Node(6);
+
+            var actualResult = _linkedListSolutions.RemoveDuplicateFromSortedList(headNode);
+
+            Assert.Equal(headNode, actualResult);
+        }
+
+        [Fact]
+        public void RemoveDuplicateFromSortedList_WithHeadNodeUsingHashSet_ReturnsResult()
+        {
+            Node headNode = new Node(4);
+            headNode.next = new Node(2);
+            headNode.next.next = new Node(8);
+            headNode.next.next.next = new Node(8);
+            headNode.next.next.next.next = new Node(4);
+            headNode.next.next.next.next.next = new Node(5);
+            headNode.next.next.next.next.next.next = new Node(6);
+            headNode.next.next.next.next.next.next.next = new Node(6);
+
+            var actualResult = _linkedListSolutions.RemoveDuplicateFromUnsortedWithHashSet(headNode);
+
+            Assert.Equal(headNode, actualResult);
+        }
+
+        [Fact]
+        public void RemoveDuplicateFromUnsortedList_WithHeadNode_ReturnsResult()
+        {
+            Node headNode = new Node(10);
+            headNode.next = new Node(3);
+            headNode.next.next = new Node(3);
+            headNode.next.next.next = new Node(2);
+            headNode.next.next.next.next = new Node(4);
+            headNode.next.next.next.next.next = new Node(6);
+            headNode.next.next.next.next.next.next = new Node(6);
+            headNode.next.next.next.next.next.next.next = new Node(5);
+
+            var actualResult = _linkedListSolutions.RemoveDuplicateFromUnsortedList(headNode);
+
+            Assert.Equal(headNode, actualResult);
+        }
+    }
+}


### PR DESCRIPTION
- The first algorithm was added for sorted linked list (the algorithm compare the value of neighboring nodes)

The time complexity of this algorithm is O(n)


- The second and third algorithms were added for the unsorted linked list, the second one uses hashset to keep track

of the value of the visited nodes, if the value of the current node never exists in the hashset but the node is removed once the value  already exists in the hashset (this takes O(n) time complexity

-  The third one uses 2 pointers and for every current node, a runner node traverses through the list and removes a node

that  is duplicate. The time complexity for this is O(n square), so it is not efficient, the second algorithm is preferable as that gives us O(n)