### PR TITLE
Added algorithm to remove the middle node without removing the head and the last node

### DIFF
--- a/DataStructuresAndAlgorithms/ILinkedListSolutions.cs
+++ b/DataStructuresAndAlgorithms/ILinkedListSolutions.cs
@@ -12,5 +12,6 @@ namespace DataStructuresAndAlgorithms
         Node RemoveDuplicateFromUnsortedList(Node head);
         Node RemoveDuplicateFromUnsortedWithHashSet(Node head);
         Node ReturnKthElement(Node head, int k);
+        Node DeleteMiddleNode(Node nodeToDelete);
     }
 }

--- a/DataStructuresAndAlgorithms/LinkedListSolutions.cs
+++ b/DataStructuresAndAlgorithms/LinkedListSolutions.cs
@@ -117,5 +117,26 @@ namespace DataStructuresAndAlgorithms
 
             return follower;
         }
+
+
+        /// <summary>
+        /// Given a node, this algorithm deletes the node in the middle without affecting the head and the last node
+        /// the time complexity for this is O(1)
+        /// No head node was given, only the node to be removed was given.
+        /// Copying the next node over to the current node would do the job
+        /// </summary>
+        /// <param name="nodeToDelete"></param>
+        /// <returns></returns>
+        public Node DeleteMiddleNode(Node nodeToDelete)
+        {
+            if (nodeToDelete == null || nodeToDelete.next == null)
+            {
+                return null;
+            }
+
+            nodeToDelete.value = nodeToDelete.next.value;
+            nodeToDelete.next = nodeToDelete.next.next;
+            return nodeToDelete;
+        }
     }
 }

--- a/DataStructuresAndAlgorithmsTest/LinkedListSolutionShould.cs
+++ b/DataStructuresAndAlgorithmsTest/LinkedListSolutionShould.cs
@@ -82,5 +82,18 @@ namespace DataStructuresAndAlgorithmsTest
 
             Assert.Equal(expectedResult, actualResult.value);
         }
+
+        [Fact]
+        public void DeleteMiddleNode_WithHeadNode_RemovesTheMiddleNode()
+        {
+            Node headNode = new Node(10);
+            headNode.next = new Node(3);
+            headNode.next.next = new Node(5);
+            headNode.next.next.next = new Node(2);
+
+            var actualResult = _linkedListSolutions.DeleteMiddleNode(headNode.next);
+
+            Assert.Equal(5, actualResult.value);
+        }
     }
 }


### PR DESCRIPTION
Added algorithm to remove the middle node without removing the head and the last node
Head node was not given, only the node to be removed is given.
The solution checks if the current is null or if the next node is null, then it returns null in that case
If otherwise, it copied the next node data and the next to the current node